### PR TITLE
FEAT: typeOrm installed, connected DB, init tables #2

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,6 +5,9 @@
 # env
 .env
 
+# config
+/config
+
 # runtime output
 package-lock.json
 

--- a/server/package.json
+++ b/server/package.json
@@ -21,10 +21,16 @@
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",
+    "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "config": "^3.3.9",
+    "pg": "^8.11.1",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "typeorm": "^0.3.17"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -2,9 +2,13 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ChatModule } from './chat/chat.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeORMConfig } from './configs/typeorm.config';
 
 @Module({
-  imports: [ChatModule],
+  imports: [
+    TypeOrmModule.forRoot(typeORMConfig),
+    ChatModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/server/src/chat/chat.entity.ts
+++ b/server/src/chat/chat.entity.ts
@@ -1,0 +1,71 @@
+import { BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+
+
+@Entity()
+export class Channel extends BaseEntity{
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    channelName: string;
+
+    @Column()
+    onwer: number;
+
+    @Column()
+    password: string;
+
+    @OneToMany(() => ChannelMember, (channelMember) => channelMember.channel)
+    channelMembers: ChannelMember[];
+}
+
+@Entity()
+export class ChannelMember extends BaseEntity{
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    userIdx: number;
+
+    @ManyToOne(() => Channel, (channel) => channel.channelMembers)
+    channel: Channel;
+}
+
+@Entity()
+export class Message extends BaseEntity{
+    @PrimaryGeneratedColumn()
+    idx: number;
+    
+    @Column()
+    channelIdx: number;
+
+    @Column()
+    permission: number;
+
+    @Column()
+    channelType: number;
+    
+    @Column()
+    mutedTime: Date;
+}
+
+// joinedChannel, channel, message
+/*
+@Entity()
+export class Board extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  description: string;
+
+  @Column()
+  status: BoardStatus;
+
+  @ManyToOne((type) => User, (user) => user.boards, { eager: false })
+  user: User;
+}
+*/

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -1,9 +1,9 @@
-import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
+// import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
 
-@WebSocketGateway()
-export class ChatGateway {
-  @SubscribeMessage('message')
-  handleMessage(client: any, payload: any): string {
-    return 'Hello world!';
-  }
-}
+// @WebSocketGateway()
+// export class ChatGateway {
+//   @SubscribeMessage('message')
+//   handleMessage(client: any, payload: any): string {
+//     return 'Hello world!';
+//   }
+// }

--- a/server/src/chat/chat.module.ts
+++ b/server/src/chat/chat.module.ts
@@ -1,10 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
-import { ChatGateway } from './chat.gateway';
 
 @Module({
   controllers: [ChatController],
-  providers: [ChatService, ChatGateway]
+  providers: [ChatService ]
 })
 export class ChatModule {}

--- a/server/src/chat/entities/chat.entity.ts
+++ b/server/src/chat/entities/chat.entity.ts
@@ -1,1 +1,0 @@
-export class Chat {}

--- a/server/src/configs/typeorm.config.ts
+++ b/server/src/configs/typeorm.config.ts
@@ -1,0 +1,15 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import * as config from 'config';
+
+const dbConfig = config.get('db');
+
+export const typeORMConfig: TypeOrmModuleOptions = {
+  type: dbConfig.type,
+  host: process.env.RDS_HOSTNAME || dbConfig.host,
+  port: process.env.RDS_PORT || dbConfig.port,
+  username: process.env.RDS_USERNAME || dbConfig.username,
+  password: process.env.RDS_PASSWORD || dbConfig.password,
+  database: 'pingpong' || dbConfig.database,
+  entities: [__dirname + '/../**/*.entity.{js,ts}'],
+  synchronize: dbConfig.synchronize,
+};

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { Logger } from '@nestjs/common';
+import * as config from 'config';
 
 async function bootstrap() {
+  const logger = new Logger();
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+
+  const serverConfig = config.get('server');
+
+  const port = serverConfig.port;
+  await app.listen(port);
+  logger.log(`Application listening on port ${port}`);
 }
 bootstrap();


### PR DESCRIPTION
- typeorm 설치
- 디비 연결 및 메인에서 받는 포트, 그 포트를 얻기 위한 config 파일 생성
- 해당 디비 스키마로 접근해서 엔터티에 맞는 매핑된 테이블들을 생성
