### PR TITLE
FEAT: chat DM repository 및 메소드 구축 #29

### DIFF
--- a/backend_server/src/chat/DM.repository.ts
+++ b/backend_server/src/chat/DM.repository.ts
@@ -1,0 +1,60 @@
+import { Repository } from 'typeorm'; // EntityRepository 가 deprecated 되어 직접 호출함
+import { CustomRepository } from 'src/typeorm-ex.decorator';
+import { DMChannel, DirectMessage } from './entities/chat.entity';
+import { SendDMDto } from './dto/send-dm.dto';
+import { UserObject } from 'src/users/entities/users.entity';
+import { first } from 'rxjs';
+
+@CustomRepository(DMChannel)
+export class DMChannelRepository extends Repository<DMChannel> {
+  async createChannel(
+    client: UserObject,
+    target: UserObject,
+    channelIdx: number,
+  ): Promise<DMChannel[]> {
+    let list;
+    const channel1 = await this.create({
+      userIdx1: client.userIdx,
+      userIdx2: target.userIdx,
+      userNickname1: client.nickname,
+      userNickname2: target.nickname,
+      channelIdx: channelIdx,
+      user1: client,
+      user2: target,
+    });
+
+    const channel2 = await this.create({
+      userIdx1: target.userIdx,
+      userIdx2: client.userIdx,
+      userNickname1: target.nickname,
+      userNickname2: client.nickname,
+      channelIdx: channelIdx,
+      user1: target,
+      user2: client,
+    });
+    list.push(channel1);
+    list.push(channel2);
+
+    return list;
+  }
+}
+
+@CustomRepository(DirectMessage)
+export class DirectMessageRepository extends Repository<DirectMessage> {
+  async sendDm(
+    sendDm: SendDMDto,
+    user: UserObject,
+    channelIdx: number,
+  ): Promise<DirectMessage> {
+    const { msg } = sendDm;
+
+    const firstDM = await this.create({
+      channelIdx: channelIdx,
+      sender: user.nickname,
+      msg: msg,
+      msgDate: new Date(),
+    });
+
+    return firstDM;
+  }
+}

--- a/backend_server/src/chat/chat.module.ts
+++ b/backend_server/src/chat/chat.module.ts
@@ -4,9 +4,17 @@ import { ChatGateway } from './chat.gateway';
 import { Chat } from './class/chat.class';
 import { Channel } from './class/channel.class';
 import { Message } from './class/message.class';
+import { DMChannelRepository, DirectMessageRepository } from './DM.repository';
+import { TypeOrmExModule } from '../typeorm-ex.module';
 
 @Module({
   // TODO: Member 와 관련된 것을 추가해야함
+  imports: [
+    TypeOrmExModule.forCustomRepository([
+      DMChannelRepository,
+      DirectMessageRepository,
+    ]),
+  ],
   providers: [ChatGateway, ChatService, Chat], // FIXME: Channel 은 어차피 Chat 으로 접근할거니까 필요 없겠지?
 })
 export class ChatModule {

--- a/backend_server/src/chat/chat.service.ts
+++ b/backend_server/src/chat/chat.service.ts
@@ -114,7 +114,7 @@ export class ChatService {
     client: UserObject,
     target: UserObject,
     channelIdx: number,
-    // msg: SendDMDto,
+    msg: SendDMDto,
   ): Promise<boolean> {
     const queryRunner = this.dataSource.createQueryRunner();
 
@@ -126,6 +126,13 @@ export class ChatService {
       target,
       channelIdx,
     );
+    const firstDM = await this.directMessagesRepository.sendDm(
+      msg,
+      client,
+      channelIdx,
+    );
+
+    await this.directMessagesRepository.save(firstDM);
 
     try {
       await queryRunner.manager.save(list[0]);

--- a/backend_server/src/chat/chat.service.ts
+++ b/backend_server/src/chat/chat.service.ts
@@ -121,7 +121,7 @@ export class ChatService {
     await queryRunner.connect();
     await queryRunner.startTransaction();
     let ret = true;
-    const list = this.dmChannelRepository.createChannel(
+    const list = await this.dmChannelRepository.createChannel(
       client,
       target,
       channelIdx,

--- a/backend_server/src/chat/dto/create-dm.dto.ts
+++ b/backend_server/src/chat/dto/create-dm.dto.ts
@@ -6,7 +6,7 @@ import {
   IsNotEmpty,
 } from 'class-validator';
 
-export class CreateChatDto {
+export class CreateDMDto {
   @IsNotEmpty()
   @IsString()
   @MaxLength(100)

--- a/backend_server/src/chat/dto/send-dm.dto.ts
+++ b/backend_server/src/chat/dto/send-dm.dto.ts
@@ -1,0 +1,19 @@
+import {
+  IsString,
+  MaxLength,
+  MinLength,
+  Matches,
+  IsNotEmpty,
+} from 'class-validator';
+
+export class SendDMDto {
+  //   @IsNotEmpty()
+  //   @IsString()
+  //   @MaxLength(100)
+  //   @MinLength(1)
+  //   @Matches(/^[a-zA-Z0-9]*$/, { message: 'nickname is unique' })
+  //   targetNickname: string;
+
+  @MaxLength(2000)
+  msg: string;
+}

--- a/backend_server/src/chat/entities/chat.entity.ts
+++ b/backend_server/src/chat/entities/chat.entity.ts
@@ -1,15 +1,15 @@
+import { UserObject } from 'src/users/entities/users.entity';
 import {
   BaseEntity,
   Column,
   Entity,
-  ManyToOne,
   OneToMany,
-  PrimaryColumn,
   PrimaryGeneratedColumn,
+  OneToOne,
 } from 'typeorm';
 
-@Entity('direct_message_members')
-export class DirectMessageMembers extends BaseEntity {
+@Entity('DMChannel')
+export class DMChannel extends BaseEntity {
   @PrimaryGeneratedColumn()
   idx: number;
 
@@ -19,12 +19,27 @@ export class DirectMessageMembers extends BaseEntity {
   @Column()
   userIdx2: number;
 
-  @OneToMany(() => DirectMessages, (message) => message.channelMember)
-  messages: DirectMessages[];
+  @Column()
+  userNickname1: string;
+
+  @Column()
+  userNickname2: string;
+
+  @Column()
+  channelIdx: number;
+
+  @OneToMany(() => DirectMessage, (channelIdx) => channelIdx.channelIdx)
+  targetChannelMessages: DirectMessage[];
+
+  @OneToOne(() => UserObject, (userIdx1) => userIdx1)
+  user1: UserObject;
+
+  @OneToOne(() => UserObject, (userIdx2) => userIdx2)
+  user2: UserObject;
 }
 
-@Entity('direct_messages')
-export class DirectMessages extends BaseEntity {
+@Entity('directMessage')
+export class DirectMessage extends BaseEntity {
   @PrimaryGeneratedColumn()
   idx: number;
 
@@ -32,17 +47,11 @@ export class DirectMessages extends BaseEntity {
   channelIdx: number;
 
   @Column()
-  sender: number;
+  sender: string;
 
   @Column()
   msg: string;
 
   @Column()
   msgDate: Date;
-
-  @ManyToOne(
-    () => DirectMessageMembers,
-    (channelMember) => channelMember.messages,
-  )
-  channelMember: DirectMessageMembers;
 }

--- a/backend_server/src/users/entities/users.entity.ts
+++ b/backend_server/src/users/entities/users.entity.ts
@@ -10,6 +10,7 @@ import {
 import { FriendList } from './friendList.entity';
 import { BlockList } from './blockList.entity';
 import { CertificateObject } from './certificate.entity';
+import { DMChannel } from 'src/chat/entities/chat.entity';
 
 export enum HistoriesType {
   NORMAL = 'NORMAL',
@@ -56,6 +57,9 @@ export class UserObject extends BaseEntity {
 
   @OneToMany(() => BlockList, (userIdx) => userIdx.userIdx)
   blockedList: BlockList[];
+
+  @OneToMany(() => DMChannel, (userIdx) => userIdx.userIdx1)
+  dmChannelList: DMChannel[];
 }
 
 // @Entity('histories')

--- a/backend_server/src/users/users.repository.ts
+++ b/backend_server/src/users/users.repository.ts
@@ -1,7 +1,6 @@
 import { Repository } from 'typeorm'; // EntityRepository 가 deprecated 되어 직접 호출함
 import { UserObject } from './entities/users.entity';
 import { CreateUsersDto } from './dto/create-users.dto';
-import { CreateHistoryDto } from './dto/create-history.dto';
 import { CustomRepository } from 'src/typeorm-ex.decorator';
 
 @CustomRepository(UserObject)


### PR DESCRIPTION
- chat.entity.ts 내부 entity 현재 erd에 맞춰 수정(이름도 직관성을 위해 수정)
- DMChannel의 경우, 필요할 수 있는 DB와의 TypeORM 설정 완료(사용자 객체 탐색1, 2, 대상 메시지 DB에서 긁어오기)
- UserObject에서 탐색 가능하도록 DmChannel리스트 연결
- DirectMessageRepository 생성, dto에 맞춰 create 메소드 레포지터리 추가
- DM Channel repository에 queryRunner 적용을 위해서 dto 없이 DB에 넣어줄 객체를 생성해주는 createChannel 메소드 생성
- QueryRunner 를 적용한 chat service 메소드 createDmChannel 메소드 작성 완료
- 컴파일 및 라우팅 문제없이 되도록 수정, DB 연결 완료