### PR TITLE
[HOTFIX] Fix chat_goto_lobby API

### DIFF
--- a/backend_server/src/chat/chat.gateway.ts
+++ b/backend_server/src/chat/chat.gateway.ts
@@ -853,19 +853,19 @@ export class ChatGateway
       );
     }
     // API: MAIN_CHAT_8
-    this.announceExit(channel);
-  }
-  async announceExit(channel: Channel) {
-    const announce = await this.chatService.exitAnnounce(channel);
-    console.log('announce : ', announce);
-    this.server
-      .to(`chat_room_${channel.getChannelIdx}`)
-      .emit('chat_room_exit', announce);
+  this.announceExit(channel);
     return this.messanger.setResponseMsgWithLogger(
       200,
       'Done exit room',
-      'chat_room_exit',
+      'chat_goto_lobby',
     );
+  }
+
+  async announceExit(channel: Channel) {
+    const announce = await this.chatService.exitAnnounce(channel);
+    this.server
+      .to(`chat_room_${channel.getChannelIdx}`)
+      .emit('chat_room_exit', announce);
   }
 
   // API: MAIN_CHAT_12
@@ -1249,14 +1249,15 @@ export class ChatGateway
     if (target.isOnline === OnlineStatus.ONGAME) {
       return new ReturnMsgDto(400, 'Bad Request, target user is on Game');
     } else if (target.isOnline === OnlineStatus.ONLINE) {
+      await this.usersService.setIsOnline(target, OnlineStatus.ONGAME);
       const invitaionCard = new GameInvitationAskDto(
         myObject.userIdx,
         myObject.nickname,
       );
-      console.log(invitaionCard);
-      console.log(target.userIdx);
-      console.log(target.nickname);
-      console.log(targetSocket.id);
+      // console.log(invitaionCard);
+      // console.log(target.userIdx);
+      // console.log(target.nickname);
+      // console.log(targetSocket.id);
       setTimeout(() => {
         targetSocket.emit('chat_invite_answer', invitaionCard);
       }, 100);

--- a/backend_server/src/chat/chat.gateway.ts
+++ b/backend_server/src/chat/chat.gateway.ts
@@ -1249,15 +1249,10 @@ export class ChatGateway
     if (target.isOnline === OnlineStatus.ONGAME) {
       return new ReturnMsgDto(400, 'Bad Request, target user is on Game');
     } else if (target.isOnline === OnlineStatus.ONLINE) {
-      await this.usersService.setIsOnline(target, OnlineStatus.ONGAME);
       const invitaionCard = new GameInvitationAskDto(
         myObject.userIdx,
         myObject.nickname,
       );
-      // console.log(invitaionCard);
-      // console.log(target.userIdx);
-      // console.log(target.nickname);
-      // console.log(targetSocket.id);
       setTimeout(() => {
         targetSocket.emit('chat_invite_answer', invitaionCard);
       }, 100);


### PR DESCRIPTION
# API : CHAT_GOT_LOBBY
1. 퍼블릭 채팅방에 들어가있는 상태에서 방을 만들었을 때, 만들어진 방으로 접속해야한다.
2. 하지만 방은 만들어지지만 로비로 이동하는 문제가 있었다.
    * 즉, 만들어진 방에 참여한 인원은 0명이 된다. 정책상 방이 사라져야하는 상황이다.
4. 만들어진 방으로 바로 접속하게 하기 위해 API 의 return 위치를 변경했다.
