### PR TITLE
[FIX] : empty nickname return to front error #216

### DIFF
--- a/backend_server/src/users/users.service.ts
+++ b/backend_server/src/users/users.service.ts
@@ -151,6 +151,9 @@ export class UsersService {
     const user = await this.findOneUser(userIdx);
     if (user.available === false && user.nickname === '') {
       user.nickname = userNickname;
+      if (userNickname === '') {
+        return user;
+      }
       try {
         await this.updateUserNick({
           userIdx,
@@ -317,7 +320,7 @@ export class UsersService {
       nickname: "",
       imgUri: `${backenduri}/img/${userIdx}.png`,
       rankpoint: 0,
-      isOnline: OnlineStatus.ONLINE,
+      isOnline: OnlineStatus.OFFLINE,
       available: false,
       win: 0,
       lose: 0,


### PR DESCRIPTION
지금 로직상엔 닉네임이 '' 로 저장된 뒤 유효한 유저로 변경이 됩니다.
디비에 접근 하기 전에 프론트 에러 받는 조건문에 부합되는 반환값을 뱉습니다.