### PR TITLE
[HOTFIX] Add set admin

### DIFF
--- a/backend_server/src/chat/chat.service.ts
+++ b/backend_server/src/chat/chat.service.ts
@@ -587,7 +587,7 @@ export class ChatService {
     if (isOwner) {
       channel.removeOwner();
       channel.setOwner = channel.getMember[0];
-      // channel.setAdmin = channel.getMember[0]; 권한이 중복됨.
+      channel.setAdmin = channel.getMember[0]; // 권한이 중복됨.
     }
     const channelsInfo = this.getPublicAndProtectedChannel().map((channel) => {
       return {


### PR DESCRIPTION
## 문제
kick, ban, mute 안되는 경우

### 상황
1. A가 방을 생성하고 들어가있음.
2. B가 A가 만든 방에 들어감
3. A가 그 방에서 LOBBY버튼을 눌러, 밖으로 나감 (dm을 하러 갔을때나 등등)
4. A가 그 방에 다시 재입장함 (이제 B가 오너)
5. B가 A에 대해 kick, ban, mute를 하려고 하면 백엔드 로그에 NOT ADMIN이 나옴

## 해결
owner 권한을 부여하면서, admin 권한도 함께 부여