### PR TITLE
Fix set admin when owner exit room

### DIFF
--- a/backend_server/src/chat/chat.gateway.ts
+++ b/backend_server/src/chat/chat.gateway.ts
@@ -892,7 +892,6 @@ export class ChatGateway
       return member.userIdx === userIdx;
     });
     if (!user) {
-      console.log('여기니?', user);
       client.disconnect();
       return this.messanger.setResponseErrorMsgWithLogger(
         400,

--- a/backend_server/src/chat/chat.service.ts
+++ b/backend_server/src/chat/chat.service.ts
@@ -571,7 +571,7 @@ export class ChatService {
     return channels;
   }
 
-  /******************* Funcions about Exit Room *******************/
+  /******************* Functions about Exit Room *******************/
 
   goToLobby(client: Socket, channel: Channel, user: UserObject) {
     console.log('chat Service : goToLobby');

--- a/backend_server/src/chat/chat.service.ts
+++ b/backend_server/src/chat/chat.service.ts
@@ -587,7 +587,7 @@ export class ChatService {
     if (isOwner) {
       channel.removeOwner();
       channel.setOwner = channel.getMember[0];
-      channel.setAdmin = channel.getMember[0]; // 권한이 중복됨.
+      channel.setAdmin = channel.getMember[0];
     }
     const channelsInfo = this.getPublicAndProtectedChannel().map((channel) => {
       return {

--- a/backend_server/src/chat/class/chat.channel/channel.class.ts
+++ b/backend_server/src/chat/class/chat.channel/channel.class.ts
@@ -89,17 +89,16 @@ export class Channel {
   set setOwner(owner: UserObject) {
     this.owner = owner;
   }
+
   set setAdmin(user: UserObject | null) {
-    // 채널에 admin 배열에 user 가 있는지 확인, 없으면 추가
-    this.admin.forEach((admin) => {
-      if (admin.userIdx === user.userIdx) {
-        return;
-      }
+    if (user === null) return;
+    const check = this.admin.some((admin) => {
+      return admin.userIdx === user.userIdx;
     });
-    if (user !== null) {
+    if (!check)
       this.admin.push(user);
-    }
   }
+
   set setBan(ban: UserObject | null) {
     if (ban !== null) {
       this.ban.push(ban);

--- a/backend_server/src/chat/class/chat.channel/channel.class.ts
+++ b/backend_server/src/chat/class/chat.channel/channel.class.ts
@@ -89,9 +89,15 @@ export class Channel {
   set setOwner(owner: UserObject) {
     this.owner = owner;
   }
-  set setAdmin(admin: UserObject | null) {
-    if (admin !== null) {
-      this.admin.push(admin);
+  set setAdmin(user: UserObject | null) {
+    // 채널에 admin 배열에 user 가 있는지 확인, 없으면 추가
+    this.admin.forEach((admin) => {
+      if (admin.userIdx === user.userIdx) {
+        return;
+      }
+    });
+    if (user !== null) {
+      this.admin.push(user);
     }
   }
   set setBan(ban: UserObject | null) {


### PR DESCRIPTION
# 같은 유저에게 Admin 이 두번 추가되는 이슈
- 퍼블릭 방에서 방장이 나가면, Owner 와 Admin 을 다른 사람에게 부여하고 나간다.
- 이때 이미 Admin 인 유저가 중복되어 추가된다.
- 중복 체크하는 로직을 추가했다.

❗️생각해보면 중복을 막는 자료구조를 사용했으면 어땠을까하는 생각이 들음