### PR TITLE
[FIX] : init_inMemUsers #225

### DIFF
--- a/backend_server/src/game/game.service.ts
+++ b/backend_server/src/game/game.service.ts
@@ -756,6 +756,10 @@ export class GameService {
             }
           }
         }
+        room.users[0].setUserObject(user1);
+        room.users[1].setUserObject(user2);
+        this.inMemoryUsers.setUserByIdFromIM(user1);
+        this.inMemoryUsers.setUserByIdFromIM(user2);
         user1.rankpoint = parseInt(user1.rankpoint.toString());
         user2.rankpoint = parseInt(user2.rankpoint.toString());
         this.processedUserIdxList.push(


### PR DESCRIPTION
#225 
조건문을 통해서 5점을 획득한 쪽이 승리 값이 증가하고 반대는 패배 값이 증가하는 기능에서
유저 테이블에 두 유저 중 승리 혹은 패배가 한 쪽에만 저장되는 이슈가 발생.
인메모리에 정보값이 한 쪽만 반영 되어 데이터베이스도 인메모리 유저 정보로 갱신되고 있었습니다.
스코어 조건 문 지나 인메모리 갱신하여 해결!