### PR TITLE
[HOTFIX] 친구가 게임 관련 페이지에서 소켓을 끊었을 때 상태값이 안바뀌는 문제

### DIFF
--- a/backend_server/src/chat/chat.gateway.ts
+++ b/backend_server/src/chat/chat.gateway.ts
@@ -118,9 +118,6 @@ export class ChatGateway
 
   async handleDisconnect(client: Socket) {
     const userId: number = parseInt(client.handshake.query.userId as string);
-    // const index = this.chat.getSocketList.findIndex((item) => item.socket.id === client.id);
-    // if (index !== -1)
-    // 	this.chat.getSocketList.splice(index, 1);
     // FIXME: 함수로 빼기
     const user = await this.inMemoryUsers.getUserByIdFromIM(userId);
     if (!user) {
@@ -163,24 +160,12 @@ export class ChatGateway
         client.leave(`chat_room_${channel.channelIdx}`);
       });
     });
-    if (user.isOnline === OnlineStatus.ONGAME) {
-      setTimeout(async () => {
-        await this.usersService.setIsOnline(user, OnlineStatus.OFFLINE);
-        this.server.emit('BR_main_enter', {
-          nickname: user.nickname,
-          userIdx: user.userIdx,
-          isOnline: OnlineStatus.ONGAME,
-        }),
-          100;
-      });
-    } else {
-      await this.usersService.setIsOnline(user, OnlineStatus.OFFLINE);
-      this.server.emit('BR_main_enter', {
-        nickname: user.nickname,
-        userIdx: user.userIdx,
-        isOnline: OnlineStatus.OFFLINE,
-      });
-    }
+    await this.usersService.setIsOnline(user, OnlineStatus.OFFLINE);
+    this.server.emit('BR_main_enter', {
+      nickname: user.nickname,
+      userIdx: user.userIdx,
+      isOnline: OnlineStatus.OFFLINE,
+    });
     client.disconnect();
     return this.messanger.setResponseMsgWithLogger(
       200,


### PR DESCRIPTION
# 문제
* 친구가 게임 관련 페이지에 있는 상태에서 창을 끊었을 때, 친구의 상태가 안바뀌는 문제가 있었음

# 해결
* chat 소켓의 handleDisconnect 부분에 잘못된 로직이 있었음. 그 부분을 삭제함.